### PR TITLE
Ease C++ Support

### DIFF
--- a/src/wooting-analog-sdk.h
+++ b/src/wooting-analog-sdk.h
@@ -7,6 +7,10 @@
 */
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef WOOTINGANALOGSDK_EXPORTS  
 #define WOOTINGANALOGSDK_API __declspec(dllexport)   
 #else  
@@ -78,3 +82,7 @@ It is not necessary to initialize the keyboard before reading. If the keyboard i
 This function returns items written and -1 on error.
 */
 WOOTINGANALOGSDK_API int wooting_read_full_buffer(uint8_t data[], unsigned int length);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Same as WootingKb/wooting-rgb-sdk#8

I don't know if this is actually something that should be in this Repo, but I wanted to offer the option.
This allows to import the SDK without requiring the `extern "C"` command in C++ Projects, and therefore make them cleaner. It has no effect on C builds/Projects.